### PR TITLE
[OPS-4821] fix the security vulnerability. ugly but required.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
+    concurrent-ruby (1.0.5)
     ethon (0.10.1)
       ffi (>= 1.3.0)
     execjs (2.7.0)
@@ -70,10 +71,11 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 2.0)
       typhoeus (~> 0.7)
-    html-pipeline (2.5.0)
+    html-pipeline (2.8.0)
       activesupport (>= 2)
-      nokogiri (>= 1.8.2)
-    i18n (0.8.1)
+      nokogiri (>= 1.4)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     jekyll (3.4.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -160,13 +162,13 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minima (2.0.0)
-    minitest (5.10.1)
+    minitest (5.11.3)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.14.0)
@@ -186,7 +188,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.3)
 
@@ -198,7 +200,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.4.4p296
 
 BUNDLED WITH
-   1.14.6
+   1.15.0


### PR DESCRIPTION
Ugly because I had to update html-pipeline as well.

```
Downloading html-pipeline-2.5.0 revealed dependencies not in the API or the lockfile (nokogiri (>= 1.4)).
Either installing with `--full-index` or running `bundle update html-pipeline` should fix the problem.
```