### PR TITLE
[TAAS-81] Update icons URI to use noun project

### DIFF
--- a/_vocabs/visual-vocab.md
+++ b/_vocabs/visual-vocab.md
@@ -8,6 +8,6 @@ contact-email: ochavisual@un.org
 
 The United Nations Office for the Coordination of Humanitarian affairs (OCHA) has created a set of 500 freely available humanitarian icons to help relief workers present emergency and crisis-related information quickly and simply.
 
-Download the icons at <http://reliefweb.int/report/world/world-humanitarian-and-country-icons-2012>
+Download the icons at <https://thenounproject.com/ochavisual/collection/ocha-humanitarian-icons-v02/>
 
 Whenever possible, credit as follows: “Source: OCHA”. 


### PR DESCRIPTION
Per TAAS-81: The OCHA Visual Vocabularies/Icons currently points to the former set of OCHA Icons and should be updated to use the Noun Project link instead.