### PR TITLE
[TAAS-82] Update OCHA services title

### DIFF
--- a/_vocabs/ocha-services.md
+++ b/_vocabs/ocha-services.md
@@ -1,6 +1,6 @@
 ---
-title: Website Navigation - OCHA Services Menu Items
-display-title: Website Navigation - OCHA Services Menu Items (BETA)
+title: OCHA Services Menu - Website Navigation
+display-title: OCHA Services Menu - Website Navigation (BETA)
 status: JSON available
 json-url: http://vocabulary.unocha.org/json/beta-v1/ocha_services.json
 gss-url: https://docs.google.com/spreadsheets/d/1DYclP1DfBN08vXoEQYK7J2Oo8MxllKTWjXBU-LHkeXE/edit#gid=856823080


### PR DESCRIPTION
The OCHA services title was using clever titling to make them show up at the end of the list, but it's based on the file name so "w" was next to "o" which was weird. This fixes that.